### PR TITLE
Fixes an error while loading pre-trained files from Google

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
-julia 0.6
+julia 0.7
+Test

--- a/src/Word2Vec.jl
+++ b/src/Word2Vec.jl
@@ -1,6 +1,7 @@
 module Word2Vec
 
 import Base: show, size
+import Statistics: norm, mean
 
 export
     # types

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,5 +1,7 @@
-"""
-     word2vec(train, output; size=100, window=5, sample=1e-3, hs=0,  negative=5, threads=12, iter=5, min_count=5, alpha=0.025, debug=2, binary=1, cbow=1, save_vocal=Void(), read_vocab=Void(), verbose=false,)
+""" word2vec(train, output; size=100, window=5, sample=1e-3, hs=0,
+     negative=5, threads=12, iter=5, min_count=5, alpha=0.025,
+     debug=2, binary=1, cbow=1, save_vocal=nothing,
+     read_vocab=nothing, verbose=false,)
 
     Parameters for training:
         train <file>
@@ -48,7 +50,7 @@ function word2vec(train::AbstractString, output::AbstractString;
                   hs::Int=0, negative::Int=5, threads::Int=12, iter::Int=5, 
                   min_count::Int=5, alpha::AbstractFloat=0.025,
                   debug::Int=2, binary::Int=0, cbow::Int=1, 
-                  save_vocab=Void(), read_vocab=Void(), 
+                  save_vocab=nothing, read_vocab=nothing,
                   verbose::Bool=false)
 
     command = joinpath(dirname(@__FILE__), "..", "deps", "src", "word2vec-c", "./word2vec")
@@ -63,11 +65,11 @@ function word2vec(train::AbstractString, output::AbstractString;
         push!(parameters, arg)
         push!(parameters, string(value))
     end
-    if save_vocab != Void()
+    if save_vocab != nothing
         push!(parameters, "-save-vocab")
         push!(parameters, string(save_vocab))
     end
-    if read_vocab != Void()
+    if read_vocab != nothing
         push!(parameters, "-read-vocab")
         push!(parameters, string(read_vocab))
     end        
@@ -75,8 +77,10 @@ function word2vec(train::AbstractString, output::AbstractString;
 end
 
 
-"""
-     word2cluster(train, output, classes; size=100, window=5, sample=1e-3, hs=0,  negative=5, threads=1, iter=5, min_count=5, alpha=0.025, debug=2, binary=1, cbow=1, save_vocal=Void(), read_vocab=Void(), verbose=false,)
+""" word2cluster(train, output, classes; size=100, window=5,
+     sample=1e-3, hs=0, negative=5, threads=1, iter=5, min_count=5,
+     alpha=0.025, debug=2, binary=1, cbow=1, save_vocal=nothing,
+     read_vocab=nothing, verbose=false,)
 
     Parameters for training:
         train <file>
@@ -129,7 +133,7 @@ function word2clusters(train::AbstractString, output::AbstractString,
                        negative::Int=5, threads::Int=1, iter::Int=5,
                        min_count::Int=5, alpha::AbstractFloat=0.025,
                        debug::Int=2, binary::Int=0, cbow::Int=1,
-                       save_vocab=Void(), read_vocab=Void(), 
+                       save_vocab=nothing, read_vocab=nothing,
                        verbose::Bool=false)
     command = joinpath(dirname(@__FILE__), "..", "deps", "src", "word2vec-c", "./word2vec")
     parameters = AbstractString[]
@@ -142,11 +146,11 @@ function word2clusters(train::AbstractString, output::AbstractString,
         push!(parameters, arg)
         push!(parameters, string(value))
     end
-    if save_vocab != Void()
+    if save_vocab != nothing
         push!(parameters, "-save-vocab")
         push!(parameters, string(save_vocab))
     end
-    if read_vocab != Void()
+    if read_vocab != nothing
         push!(parameters, "-read-vocab")
         push!(parameters, string(read_vocab))
     end 

--- a/src/wordclusters.jl
+++ b/src/wordclusters.jl
@@ -58,7 +58,7 @@ For the WordCluster `wc`, return all the words from a given cluster
 number `cluster`.
 """
 function get_words(wc::WordClusters, cluster::Int)
-    inds = findin(wc.clusters, cluster)
+    inds = findall(isequal(cluster), wc.clusters)
     return wc.vocab[inds]
 end
 

--- a/test/model.jl
+++ b/test/model.jl
@@ -30,7 +30,7 @@ n = rand(1:100)
 indxs, mes = cosine(model, word1, n)
 @test words[indxs] == cosine_similar_words(model, word1, n)
 w4_indx = indxs[rand(1:end)]
-loc = findin(indxs, w4_indx)
+loc = findall((in)(w4_indx), indxs)
 word4 = words[w4_indx]
 @test index(model, word4) == w4_indx
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Word2Vec
-using Base.Test
+using Test
 
 include("train.jl") 
 include("model.jl")


### PR DESCRIPTION
Allows loading of original Word2Vec pre-trained files by Google (e.g from [here](https://code.google.com/archive/p/word2vec/)), mentioned in #3.

If a `UnicodeError` is detected while `kind=:binary`, the loader informs the user and automatically tries to load it with the google-type-loader.

There is also an additional option for kind `:google` to force the new loader