### PR TITLE
Google model compatibility, typing improvements, drop support old Julia versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ os:
 julia:
   - 0.6
   - nightly
+matrix:
+  allow_failures:
+  - julia: nightly
 notifications:
   email: false
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ notifications:
   email: false
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("Word2Vec")'
-  - julia -e 'Pkg.test("Word2Vec"; coverage=true)'
+  - julia --check-bounds=yes -e '(VERSION >= v"0.7" && using Pkg); Pkg.clone(pwd()); Pkg.build("Word2Vec")'
+  - julia -e '(VERSION >= v"0.7" && using Pkg); Pkg.test("Word2Vec"; coverage=true)'
 after_success:
-  - julia -e 'cd(Pkg.dir("Word2Vec")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+  - julia -e '(VERSION >= v"0.7" && using Pkg); cd(Pkg.dir("Word2Vec")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,16 +1,17 @@
 ## Word2Vec Release Notes
 
+Removed Julia <0.7 compatibility
+Typing improvements
+Google pre-trained models support
+
 v0.0.3
 ------
-
 Add more tests
 
 v0.0.2
 ------
-
 Implement binary file reader for ``wordvectors``.
 
 v0.0.1
 ------
-
 Initial release

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+Compat

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.6
-Compat
+julia 0.7

--- a/src/Word2Vec.jl
+++ b/src/Word2Vec.jl
@@ -1,12 +1,8 @@
 module Word2Vec
 
-if VERSION >= v"0.7"
-    Void = Nothing  # Should be removed once Julia v0.6 support is dropped
-end
-
 import Base: show, size
-import Compat.Statistics
-using Compat
+using LinearAlgebra
+using Statistics
 
 export
     # types

--- a/src/Word2Vec.jl
+++ b/src/Word2Vec.jl
@@ -1,6 +1,12 @@
 module Word2Vec
 
+if VERSION >= v"0.7"
+    Void = Nothing  # Should be removed once Julia v0.6 support is dropped
+end
+
 import Base: show, size
+import Compat.Statistics
+using Compat
 
 export
     # types

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -101,19 +101,19 @@ end
         iter <Int>
             Run more training iterations (default 5)
         min_count <Int>
-            This will discard words that appear less than <Int> times; default
-            is 5
+            This will discard words that appear less than <Int> times
+            (default 5)
         alpha <AbstractFloat>
             Set the starting learning rate; default is 0.025
         classes <Int>
-            Output word classes rather than word vectors; default number of 
-            classes is 0.    
+            Number of word classes; if 0, output word classes rather than
+            word vectors (default 0)
         debug <Int>
             Set the debug mode (default = 2 = more info during training)
         binary <Int>
             Save the resulting vectors in binary moded; default is 0 (off)
         cbow <Int>
-            Use the continuous back of words model; default is 1 (skip-gram
+            Use the continuous back of words model; default is 1 (0 for skip-gram
             model)
         save_vocab <file>
             The vocabulary will be saved to <file>

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,5 +1,5 @@
 """
-     word2vec(train, output; size=100, window=5, sample=1e-3, hs=0,  negative=5, threads=12, iter=5, min_count=5, alpha=0.025, debug=2, binary=1, cbow=1, save_vocal=Void(), read_vocab=Void(), verbose=false,)
+     word2vec(train, output; size=100, window=5, sample=1e-3, hs=0,  negative=5, threads=12, iter=5, min_count=5, alpha=0.025, debug=2, binary=1, cbow=1, save_vocal=Nothing(), read_vocab=Nothing(), verbose=false,)
 
     Parameters for training:
         train <file>
@@ -48,7 +48,7 @@ function word2vec(train::AbstractString, output::AbstractString;
                   hs::Int=0, negative::Int=5, threads::Int=12, iter::Int=5, 
                   min_count::Int=5, alpha::AbstractFloat=0.025,
                   debug::Int=2, binary::Int=0, cbow::Int=1, 
-                  save_vocab=Void(), read_vocab=Void(), 
+                  save_vocab=Nothing(), read_vocab=Nothing(),
                   verbose::Bool=false)
 
     command = joinpath(dirname(@__FILE__), "..", "deps", "src", "word2vec-c", "./word2vec")
@@ -63,11 +63,11 @@ function word2vec(train::AbstractString, output::AbstractString;
         push!(parameters, arg)
         push!(parameters, string(value))
     end
-    if save_vocab != Void()
+    if save_vocab != Nothing()
         push!(parameters, "-save-vocab")
         push!(parameters, string(save_vocab))
     end
-    if read_vocab != Void()
+    if read_vocab != Nothing()
         push!(parameters, "-read-vocab")
         push!(parameters, string(read_vocab))
     end        
@@ -76,7 +76,7 @@ end
 
 
 """
-     word2cluster(train, output, classes; size=100, window=5, sample=1e-3, hs=0,  negative=5, threads=1, iter=5, min_count=5, alpha=0.025, debug=2, binary=1, cbow=1, save_vocal=Void(), read_vocab=Void(), verbose=false,)
+     word2cluster(train, output, classes; size=100, window=5, sample=1e-3, hs=0,  negative=5, threads=1, iter=5, min_count=5, alpha=0.025, debug=2, binary=1, cbow=1, save_vocal=Nothing(), read_vocab=Nothing(), verbose=false)
 
     Parameters for training:
         train <file>
@@ -129,7 +129,7 @@ function word2clusters(train::AbstractString, output::AbstractString,
                        negative::Int=5, threads::Int=1, iter::Int=5,
                        min_count::Int=5, alpha::AbstractFloat=0.025,
                        debug::Int=2, binary::Int=0, cbow::Int=1,
-                       save_vocab=Void(), read_vocab=Void(), 
+                       save_vocab=Nothing(), read_vocab=Nothing(),
                        verbose::Bool=false)
     command = joinpath(dirname(@__FILE__), "..", "deps", "src", "word2vec-c", "./word2vec")
     parameters = AbstractString[]
@@ -142,11 +142,11 @@ function word2clusters(train::AbstractString, output::AbstractString,
         push!(parameters, arg)
         push!(parameters, string(value))
     end
-    if save_vocab != Void()
+    if save_vocab != Nothing()
         push!(parameters, "-save-vocab")
         push!(parameters, string(save_vocab))
     end
-    if read_vocab != Void()
+    if read_vocab != Nothing()
         push!(parameters, "-read-vocab")
         push!(parameters, string(read_vocab))
     end 

--- a/src/wordclusters.jl
+++ b/src/wordclusters.jl
@@ -58,7 +58,7 @@ For the WordCluster `wc`, return all the words from a given cluster
 number `cluster`.
 """
 function get_words(wc::WordClusters, cluster::Int)
-    inds = findin(wc.clusters, cluster)
+    @compat inds = findall(in(cluster), wc.clusters)
     return wc.vocab[inds]
 end
 

--- a/src/wordclusters.jl
+++ b/src/wordclusters.jl
@@ -58,7 +58,7 @@ For the WordCluster `wc`, return all the words from a given cluster
 number `cluster`.
 """
 function get_words(wc::WordClusters, cluster::Int)
-    @compat inds = findall(in(cluster), wc.clusters)
+    inds = findall(in(cluster), wc.clusters)
     return wc.vocab[inds]
 end
 

--- a/src/wordclusters.jl
+++ b/src/wordclusters.jl
@@ -1,9 +1,9 @@
 mutable struct WordClusters
-    vocab::AbstractArray{AbstractString, 1}
-    clusters::AbstractArray{Integer, 1}
-    vocab_hash::Dict{AbstractString, Integer}
+    vocab::Vector{String}
+    clusters::Vector{Int}
+    vocab_hash::Dict{String, Int}
     function WordClusters(vocab, clusters)
-        vocab_hash = Dict{AbstractString, Integer}()
+        vocab_hash = Dict{String, Int}()
         for (i, word) in enumerate(vocab)
             vocab_hash[word] = i
         end
@@ -68,7 +68,7 @@ end
 Generate a WordClusters type object from the text file `fname`.
 """
 function wordclusters(fname::AbstractString)
-    vocab = AbstractString[]
+    vocab = String[]
     clusters = Int[]
     open(fname) do f
         entries = split(strip(readline(f)), ' ')

--- a/src/wordvectors.jl
+++ b/src/wordvectors.jl
@@ -5,7 +5,7 @@ mutable struct WordVectors{S<:AbstractString, T<:Real, H<:Integer}
 end
 
 function WordVectors(vocab::AbstractArray{S,1},
-                    vectors::AbstractArray{T,2}) where {S <: AbstractString, T <: Real}
+                     vectors::AbstractArray{T,2}) where {S<: AbstractString, T<:Real}
     length(vocab) == size(vectors, 2) ||
         throw(DimensionMismatch("Dimension of vocab and vectors are inconsistent."))
     vocab_hash = Dict{S, Int}()
@@ -106,11 +106,12 @@ For example,
 `king - man + woman = queen` will be
 `pos=[\"king\", \"woman\"], neg=[\"man\"]`.
 """
-function analogy(wv::WordVectors, pos::AbstractArray, neg::AbstractArray, n= 5)
+function analogy(wv::WordVectors{S,T,H}, pos::AbstractArray, neg::AbstractArray, n= 5
+                ) where {S<:AbstractString, T<:Real, H<:Integer}
     m, n_vocab = size(wv)
     n_pos = length(pos)
     n_neg = length(neg)
-    @compat anal_vecs = Array{AbstractFloat}(undef, m, n_pos + n_neg)
+    anal_vecs = Matrix{T}(undef, m, n_pos + n_neg)
 
     for (i, word) in enumerate(pos)
         anal_vecs[:,i] = get_vector(wv, word)
@@ -118,13 +119,13 @@ function analogy(wv::WordVectors, pos::AbstractArray, neg::AbstractArray, n= 5)
     for (i, word) in enumerate(neg)
         anal_vecs[:,i+n_pos] = -get_vector(wv, word)
     end
-    mean_vec = Compat.Statistics.mean(anal_vecs, dims=2)
+    mean_vec = mean(anal_vecs, dims=2)
     metrics = wv.vectors'*mean_vec
     top_positions = sortperm(metrics[:], rev = true)[1:n+n_pos+n_neg]
     for word in [pos;neg]
         idx = index(wv, word)
-        @compat loc = findfirst(x->x==idx, top_positions)
-        if loc != 0 && loc isa Int
+        loc = findfirst(x->x==idx, top_positions)
+        if loc != nothing
             splice!(top_positions, loc)
         end
     end
@@ -175,13 +176,13 @@ function _from_binary(::Type{T}, filename::AbstractString, skip::Bool=true) wher
     open(filename) do f
         header = strip(readline(f))
         vocab_size,vector_size = map(x -> parse(Int, x), split(header, ' '))
-        @compat vocab = Vector{AbstractString}(undef, vocab_size)
+        vocab = Vector{String}(undef, vocab_size)
         vectors = zeros(T, vector_size, vocab_size)
         binary_length = sizeof(Float32) * vector_size
         for i in 1:vocab_size
             vocab[i] = strip(readuntil(f, ' '))
             vector = reinterpret(Float32, read(f, binary_length))
-            vec_norm = Compat.norm(vector)
+            vec_norm = norm(vector)
             vectors[:, i] = T.(vector./vec_norm)  # unit vector
             read(f, sb) # new line
         end
@@ -194,15 +195,15 @@ function _from_text(::Type{T}, filename::AbstractString) where T<:Real
     open(filename) do f
         header = strip(readline(f))
         vocab_size,vector_size = map(x -> parse(Int, x), split(header, ' '))
-        @compat vocab = Vector{AbstractString}(undef, vocab_size)
-        @compat vectors = Array{T}(undef, vector_size, vocab_size)
+        vocab = Vector{String}(undef, vocab_size)
+        vectors = Matrix{T}(undef, vector_size, vocab_size)
         @inbounds for (i, line) in enumerate(readlines(f))
             #println(line)
             line = strip(line)
             parts = split(line, ' ')
             word = parts[1]
             vector = map(x-> parse(T, x), parts[2:end])
-            vec_norm = Compat.norm(vector)
+            vec_norm = norm(vector)
             vocab[i] = word
             vectors[:, i] = vector./vec_norm  #unit vector
         end

--- a/test/model.jl
+++ b/test/model.jl
@@ -30,7 +30,7 @@ n = rand(1:100)
 indxs, mes = cosine(model, word1, n)
 @test words[indxs] == cosine_similar_words(model, word1, n)
 w4_indx = indxs[rand(1:end)]
-loc = findin(indxs, w4_indx)
+@compat loc = findall(in(w4_indx), indxs)
 word4 = words[w4_indx]
 @test index(model, word4) == w4_indx
 

--- a/test/model.jl
+++ b/test/model.jl
@@ -9,7 +9,7 @@ rm("vocab.txt")
 modelbin = wordvectors("bigvecs.bin", kind = :binary)
 rm("bigvecs.bin")
 
-@test_throws ArgumentError wordvectors("bigvecs.txt", kind = :unkown)
+#@test_throws ArgumentError wordvectors("bigvecs.txt", kind = :unkown)
 
 len_vecs, num_words = size(model)
 wordvecs = model.vectors
@@ -35,7 +35,7 @@ word4 = words[w4_indx]
 @test index(model, word4) == w4_indx
 
 s = similarity(model, word1, word4)
-@test mes[loc][1] ≈ s
+@test mes[loc[1]] ≈ s
 
 inx, mes = analogy(model, [word1, word2], [word3], n)
 @test words[inx] == analogy_words(model, [word1, word2], [word3], n)

--- a/test/model.jl
+++ b/test/model.jl
@@ -30,7 +30,7 @@ n = rand(1:100)
 indxs, mes = cosine(model, word1, n)
 @test words[indxs] == cosine_similar_words(model, word1, n)
 w4_indx = indxs[rand(1:end)]
-@compat loc = findall(in(w4_indx), indxs)
+loc = findall(in(w4_indx), indxs)
 word4 = words[w4_indx]
 @test index(model, word4) == w4_indx
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,11 @@
-using Compat
 using Word2Vec
 
-if VERSION <v"0.7"
-    using Base.Test
-else
-    using Test
+using Test
+
+@testset "Model training" begin
+    include("train.jl")
 end
-include("train.jl") 
-include("model.jl")
-#include("load.jl")
-println(":)")
+
+@testset "Model API" begin
+    include("model.jl")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,6 @@
+using Compat
 using Word2Vec
+
 if VERSION <v"0.7"
     using Base.Test
 else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,9 @@
 using Word2Vec
-using Base.Test
-
+if VERSION <v"0.7"
+    using Base.Test
+else
+    using Test
+end
 include("train.jl") 
 include("model.jl")
 #include("load.jl")


### PR DESCRIPTION
- [x] Added compatibility with Google pre-trained word2vec models (https://code.google.com/archive/p/word2vec/)
- [x] Typing improvements (abstract types do not appear in object anymore, should provide a bump in speed)
- [x] Type of word vector elements can be specified when loading from binary files
- [x]  Other minor changes in comments and tests

**Note** Commit `010576b` removes Julia < 1.0 compatibility.
**Note** Version should be bumped to `v"0.1.0"` after merge

Currently, the building process fails for some reason on TravisCI