### PR TITLE
FastText embedding loading fix (text format only)

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,23 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,17 @@
+name = "Word2Vec"
+uuid = "07718ad2-0e07-11eb-1044-2f7de2a2b708"
+author = ["Corneliu Cofaru <cornel@oxoaresearch.com>"]
+version = "0.5.0"
+
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[compat]
+julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]


### PR DESCRIPTION
The FastText text embeddings have a similar format to the word2vec text ones and loading should work out of the box.

However, in certain pre-trained models (for example [this one](https://dl.fbaipublicfiles.com/fasttext/vectors-aligned/wiki.ro.align.vec)) loading fails because of the removal of leading whitespace and delimiters prior to line parsing i.e. `strip(line)`. This pull fixes the issue by adding a keyword argument `fasttext::Bool` (default `false`) which allows to skip the stripping step prior to line parsing.